### PR TITLE
Update action.yml to support changing the assumed project directory

### DIFF
--- a/build-godot/action.yml
+++ b/build-godot/action.yml
@@ -2,6 +2,10 @@ name: 'Build Godot'
 description: 'Build Godot applications for Windows, macOS, and Linux'
 
 inputs:
+  project-dir:
+    description: 'The path to the Godot project (folder that contains the project.godot file)'
+    required: false
+    default: ''
   build-dir:
     description: 'The chosen build directory'
     required: true
@@ -16,14 +20,17 @@ runs:
   steps:
     - name: Open Godot editor for reimport
       shell: bash
+      working-directory: ${{ inputs.project-dir }}
       run: ${{ inputs.godot-executable }} --import --headless --verbose
 
     - name: Apply version to export information
       shell: bash
+      working-directory: ${{ inputs.project-dir }}
       run: ${{ inputs.godot-executable }} --script scripts/apply_version.gd --headless
       
     - name: Build macOS application
       shell: bash
+      working-directory: ${{ inputs.project-dir }}
       run: |
         mkdir -p ${{ inputs.build-dir }}/macos
         ${{ inputs.godot-executable }} --export-debug macOS --headless
@@ -31,6 +38,7 @@ runs:
 
     - name: Compress macOS build (to preserve permissions)
       shell: bash
+      working-directory: ${{ inputs.project-dir }}
       run: |
         cd ${{ inputs.build-dir }}/macos
         tar -cvf ./macos.tar --exclude='*.command' ./*
@@ -38,10 +46,11 @@ runs:
     - uses: actions/upload-artifact@v3
       with:
         name: macos
-        path: ${{ inputs.build-dir }}/macos/macos.tar
+        path: ${{ inputs.project-dir }}${{ inputs.build-dir }}/macos/macos.tar
 
     - name: Build Windows application
       shell: bash
+      working-directory: ${{ inputs.project-dir }}
       run: |
         mkdir -p ${{ inputs.build-dir }}/windows
         ${{ inputs.godot-executable }} --export-debug Windows --headless
@@ -49,6 +58,7 @@ runs:
 
     - name: Compress Windows build
       shell: bash
+      working-directory: ${{ inputs.project-dir }}
       run: |
         cd ${{ inputs.build-dir }}/windows
         zip -m ./windows.zip ./*
@@ -56,10 +66,11 @@ runs:
     - uses: actions/upload-artifact@v3
       with:
         name: windows
-        path: ${{ inputs.build-dir }}/windows/windows.zip
+        path: ${{ inputs.project-dir }}${{ inputs.build-dir }}/windows/windows.zip
 
     - name: Build Linux application
       shell: bash
+      working-directory: ${{ inputs.project-dir }}
       run: |
         mkdir -p ${{ inputs.build-dir }}/linux
         ${{ inputs.godot-executable }} --export-debug Linux --headless
@@ -67,6 +78,7 @@ runs:
 
     - name: Compress Linux build (to preserve permissions)
       shell: bash
+      working-directory: ${{ inputs.project-dir }}
       run: |
         cd ${{ inputs.build-dir }}/linux
         tar -cvf ./linux.tar ./*
@@ -74,4 +86,4 @@ runs:
     - uses: actions/upload-artifact@v3
       with:
         name: linux
-        path: ${{ inputs.build-dir }}/linux/linux.tar
+        path: ${{ inputs.project-dir }}${{ inputs.build-dir }}/linux/linux.tar


### PR DESCRIPTION
From issue #2:
> Also, is this a stand-alone script or should this be in my godot project's scripts folder? because my project is inside a folder named src, so unless there is a way to tell the Apply version to export information step to change its working directory, there are file path assumptions that won't work with my project being inside a folder instead of the root of the repo.